### PR TITLE
Feature/multi layer cache

### DIFF
--- a/benchmark/fetch-hit-full.ts
+++ b/benchmark/fetch-hit-full.ts
@@ -9,7 +9,7 @@ import {
 import {
   RedisDriver as DevelopSingleDriver,
   RedisClusterDriver as DevelopClusterDriver,
-  MemcachedFetcher as DevelopFetcher,
+  CachedFetcher as DevelopFetcher,
 } from "../src";
 import { isMainThread } from "worker_threads";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -670,6 +670,11 @@
         }
       }
     },
+    "@types/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
+    },
     "@types/minimist": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
@@ -2697,7 +2702,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -6540,8 +6544,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
   },
   "dependencies": {
     "@types/ioredis": "^4.26.4",
-    "ioredis": "^4.27.6"
+    "@types/lru-cache": "^5.1.1",
+    "ioredis": "^4.27.6",
+    "lru-cache": "^6.0.0"
   },
   "config": {
     "commitizen": {

--- a/src/__test__/fetcher_spec.ts
+++ b/src/__test__/fetcher_spec.ts
@@ -2,19 +2,245 @@ import { expect } from "chai";
 import * as sinon from "sinon";
 
 import {
+  LocalStorageDriver,
   RedisDriver,
 } from "../drivers";
+import { Driver } from "../drivers/base";
 
-import { MemcachedFetcher } from "../fetcher";
+import { CachedFetcher } from "../fetcher";
 
-const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+describe(CachedFetcher.name, () => {
+  context("With multidriver", () => {
+    describe("#fetch", () => {
+      const drivers: [Driver, Driver] = [
+        new LocalStorageDriver(),
+        new RedisDriver(process.env.REDIS_URL as string),
+      ];
+      const subject: CachedFetcher = new CachedFetcher(drivers);
 
-describe(MemcachedFetcher.name, () => {
+      beforeEach(async () => {
+        await Promise.all(drivers.map((driver) => driver.flush()));
+      });
+
+      context("when L1/L2 both doens't have data", () => {
+        it("should populate data for both L1/L2", async () => {
+          const value = 100;
+          const fn = sinon.fake.resolves(value);
+
+          const key = "random-key";
+          const v1 = await subject.fetch(key, 60, fn);
+          expect(fn.callCount).to.eq(1);
+          expect(v1).to.deep.eq(value);
+
+          const v2 = await subject.fetch(key, 60, fn);
+          // Should cache the value
+          expect(fn.callCount).to.eq(1);
+          expect(v2).to.deep.eq(value);
+
+          // both drivers should have data now
+          expect(await drivers[0].get(key)).to.be.eq(value);
+          expect(await drivers[1].get(key)).to.be.eq(value);
+        });
+      });
+
+      context("when only L1 has cached data", () => {
+        it("should only access L1, and return the data", async () => {
+          const fetcher = async () => 100;
+          const key = "random-key";
+
+          await drivers[0].set(key, await fetcher());
+
+          expect(await subject.fetch(key, 60, fetcher))
+            .to.be.deep.eq(100);
+
+          expect(await drivers[0].get(key)).to.be.eq(100, "L1 should have it");
+          expect(await drivers[1].get(key)).to.be.eq(undefined, "L2 still doesn't have it");
+        });
+      });
+
+      context("when only L2 has cached data", () => {
+        it("should fill the L1, and return the data", async () => {
+          const fetcher = async () => 100;
+          const key = "random-key";
+
+          // Fill L2
+          await drivers[1].set(key, await fetcher());
+
+          expect(await subject.fetch(key, 60, fetcher))
+            .to.be.deep.eq(100);
+
+          // L1 has to be popluated
+          expect(await drivers[0].get(key)).to.be.eq(100);
+          expect(await drivers[1].get(key)).to.be.eq(100);
+        });
+      });
+    });
+
+
+    describe("#multiFetch", () => {
+      const L1 = new LocalStorageDriver();
+      const L2 = new LocalStorageDriver();
+      const L3 = new LocalStorageDriver();
+      const drivers = [L1, L2, L3] as const;
+      const subject: CachedFetcher = new CachedFetcher([...drivers]);
+
+      beforeEach(async () => {
+        await Promise.all(drivers.map((driver) => driver.flush()));
+      });
+
+      context("when cache has cascaded discrepency", () => {
+        beforeEach(async () => {
+          await L1.setMulti([
+            { key: "key:A", value: "A" },
+          ]);
+          await L2.setMulti([
+            { key: "key:A", value: "A" },
+            { key: "key:B", value: "B" },
+          ]);
+          await L3.setMulti([
+            { key: "key:A", value: "A" },
+            { key: "key:B", value: "B" },
+            { key: "key:C", value: "C" },
+          ]);
+        });
+
+        it("should return cached value, and fill the upwards caches", async () => {
+          const res1 = await subject.multiFetch(
+            ["A", "B", "C", "D"],
+            "key",
+            3600,
+            async (args) => {
+              return args.map(() => "NEW");
+            },
+          );
+
+          expect(res1).to.deep.eq(["A", "B", "C", "NEW"]);
+
+          // All Caches should be filled upwards
+          for (const cache of [L1,L2,L3]) {
+            expect(await cache.getMulti(["key:A", "key:B", "key:C", "key:D"])).to.be.deep.eq({
+              "key:A": "A",
+              "key:B": "B",
+              "key:C": "C",
+              "key:D": "NEW",
+            });
+          }
+        });
+      });
+
+      it("should fetch only missing sets", async () => {
+        const res1 = await subject.multiFetch(
+          [1, 2, 3, 4, 5],
+          "v1",
+          3600,
+          async (args) => {
+            return args.map((arg) => arg * arg);
+          },
+        );
+        expect(res1).to.deep.eq([1, 4, 9, 16, 25]);
+
+        // it's using same hash key, so should reuse cache for exsiting values
+        const res2 = await subject.multiFetch(
+          [1, 2, 100, 200, 5],
+          ["v1", (arg) => arg],
+          3600,
+          async (args) => {
+            return args.map((arg) => arg + arg);
+          },
+        );
+        expect(res2).to.deep.eq([1, 4, 200, 400, 25]);
+
+        let fetcherCalled = false;
+        const res3 = await subject.multiFetch(
+          [],
+          ["v1", (arg) => arg],
+          3600,
+          async (args) => {
+            fetcherCalled = true;
+            return args.map((arg) => arg);
+          },
+        );
+        expect(fetcherCalled).to.be.eq(false);
+        expect(res3).to.deep.eq([]);
+      });
+
+      it("should cache the value <0>", async () => {
+        const res1 = await subject.multiFetch(
+          [1, 2, 0],
+          "v1",
+          3600,
+          async (args) => args,
+        );
+        expect(res1).to.deep.eq([1, 2, 0]);
+
+        const res2 = await subject.multiFetch(
+          [1, 2, 0, 0],
+          "v1",
+          3600,
+          async (args) => args.map((__) => 100),
+        );
+        expect(res2).to.deep.eq([1, 2, 0, 0]);
+      });
+
+      it("should cache the value <null>", async () => {
+        const res1 = await subject.multiFetch(
+          [1, 2, 3, 4],
+          "v1",
+          3600,
+          async (args) => {
+            return args.map((i) => {
+              if (i % 2 === 0) {
+                return null;
+              } else {
+                return i;
+              }
+            });
+          },
+        );
+        expect(res1).to.deep.eq([1, null, 3, null]);
+
+        const res2 = await subject.multiFetch(
+          [1, 2, 3, 4],
+          "v1",
+          3600,
+          async (args) => args.map((__) => -1),
+        );
+        expect(res2).to.deep.eq([1, null, 3, null]);
+      });
+
+      it("should not cache the value undefined, and revalidate next time", async () => {
+        const res1 = await subject.multiFetch(
+          [1, 2, 3, 4],
+          "v1",
+          3600,
+          async (args) => {
+            return args.map((i) => {
+              if (i % 2 === 0) {
+                return undefined;
+              } else {
+                return i;
+              }
+            });
+          },
+        );
+        expect(res1).to.deep.eq([1, undefined, 3, undefined]);
+
+        const res2 = await subject.multiFetch(
+          [1, 2, 3, 4],
+          "v1",
+          3600,
+          async (args) => args.map((__) => -1),
+        );
+        expect(res2).to.deep.eq([1, -1, 3, -1]);
+      });
+    });
+  });
+
   [
     new RedisDriver(process.env.REDIS_URL as string),
   ].forEach((driver) => {
     context(`with ${driver.constructor.name}`, () => {
-      const fetcher = new MemcachedFetcher(driver);
+      const fetcher = new CachedFetcher([driver]);
 
       beforeEach(async () => {
         await driver.flush();
@@ -22,22 +248,22 @@ describe(MemcachedFetcher.name, () => {
 
       describe("#constructor - keyTransform", () => {
         it("should transform with type=hashing", async () => {
-          const subject = new MemcachedFetcher(driver, { keyTransform: { type: "hashing", algorithm: "md5" }}).keyTransform;
+          const subject = new CachedFetcher([driver], { keyTransform: { type: "hashing", algorithm: "md5" }}).keyTransform;
           expect(subject("abc")).to.be.eq("900150983cd24fb0d6963f7d28e17f72");
         });
 
         it("should transform with type=prefix", async () => {
-          const subject = new MemcachedFetcher(driver, { keyTransform: { type: "prefix", prefix: "service:" }}).keyTransform;
+          const subject = new CachedFetcher([driver], { keyTransform: { type: "prefix", prefix: "service:" }}).keyTransform;
           expect(subject("abc")).to.be.eq("service:abc");
         });
 
         it("should transform with custom transform", async () => {
-          const subject = new MemcachedFetcher(driver, { keyTransform: (key) => `!!${key}!!`}).keyTransform;
+          const subject = new CachedFetcher([driver], { keyTransform: (key) => `!!${key}!!`}).keyTransform;
           expect(subject("abc")).to.be.eq("!!abc!!");
         });
 
         it("should bypass transform as default", async () => {
-          const subject = new MemcachedFetcher(driver, {}).keyTransform;
+          const subject = new CachedFetcher([driver], {}).keyTransform;
           expect(subject("abc")).to.be.eq("abc");
         });
       });
@@ -53,31 +279,6 @@ describe(MemcachedFetcher.name, () => {
           const v2 = await fetcher.fetch("fetch", 60, fn);
           expect(fn.callCount).to.eq(1);
           expect(v2).to.deep.eq({ fake: 3 });
-        });
-
-        it("should update stale cache", async () => {
-          await fetcher.fetch("fetch", { cacheTime: 3600, staleTime: 3 }, async () => ({
-            fake: "xoxo",
-          }));
-
-          await sleep(3500);
-
-          const fn = sinon.fake.resolves({ fake: "yes" });
-          const res = await fetcher.fetch("fetch", { cacheTime: 3600, staleTime: 3 }, fn);
-          expect(res).to.deep.eq({ fake: "yes" });
-        });
-
-        it("should return stale cache if fetcher thrown an error", async () => {
-          await fetcher.fetch("fetch", { cacheTime: 10, staleTime: 5 }, async () => ({
-            fake: "xoxo",
-          }));
-
-          await sleep(5500);
-
-          const fn = sinon.fake.rejects(new Error("MOCKED"));
-          const res = await fetcher.fetch("fetch", { cacheTime: 10, staleTime: 5 }, fn);
-
-          expect(res).to.deep.eq({ fake: "xoxo" });
         });
       });
 

--- a/src/__test__/fetcher_spec.ts
+++ b/src/__test__/fetcher_spec.ts
@@ -93,12 +93,12 @@ describe(CachedFetcher.name, () => {
             { key: "key:A", value: "A" },
           ]);
           await L2.setMulti([
-            { key: "key:A", value: "A" },
+            { key: "key:A", value: "A-L2" },
             { key: "key:B", value: "B" },
           ]);
           await L3.setMulti([
-            { key: "key:A", value: "A" },
-            { key: "key:B", value: "B" },
+            { key: "key:A", value: "A-L3" },
+            { key: "key:B", value: "B-L3" },
             { key: "key:C", value: "C" },
           ]);
         });
@@ -115,15 +115,24 @@ describe(CachedFetcher.name, () => {
 
           expect(res1).to.deep.eq(["A", "B", "C", "NEW"]);
 
-          // All Caches should be filled upwards
-          for (const cache of [L1,L2,L3]) {
-            expect(await cache.getMulti(["key:A", "key:B", "key:C", "key:D"])).to.be.deep.eq({
-              "key:A": "A",
-              "key:B": "B",
-              "key:C": "C",
-              "key:D": "NEW",
-            });
-          }
+          expect(await L1.getMulti(["key:A", "key:B", "key:C", "key:D"])).to.be.deep.eq({
+            "key:A": "A",
+            "key:B": "B",
+            "key:C": "C",
+            "key:D": "NEW",
+          });
+          expect(await L2.getMulti(["key:A", "key:B", "key:C", "key:D"])).to.be.deep.eq({
+            "key:A": "A-L2",
+            "key:B": "B",
+            "key:C": "C",
+            "key:D": "NEW",
+          });
+          expect(await L3.getMulti(["key:A", "key:B", "key:C", "key:D"])).to.be.deep.eq({
+            "key:A": "A-L3",
+            "key:B": "B-L3",
+            "key:C": "C",
+            "key:D": "NEW",
+          });
         });
       });
 

--- a/src/drivers/__test__/local_stroage_spec.ts
+++ b/src/drivers/__test__/local_stroage_spec.ts
@@ -1,0 +1,55 @@
+import { expect } from "chai";
+
+import { LocalStorageDriver } from "../local_storage";
+
+describe(LocalStorageDriver.name, () => {
+  let subject: LocalStorageDriver;
+  beforeEach(() => {
+    subject = new LocalStorageDriver();
+  });
+
+  describe("#get", () => {
+    it("should return cached value", async () => {
+      await subject.set("A", 100);
+      expect(await subject.get("A")).to.be.eq(100);
+    });
+
+    it("should return undefined for missing keys", async () => {
+      expect(await subject.get("A")).to.be.eq(undefined);
+    });
+
+    it("should expire value if TTL is up", async () => {
+      await subject.set("A", 100, 1);
+      await new Promise((resolve) => setTimeout(resolve, 0.6 * 1000));
+      expect(await subject.get("A")).to.be.eq(100, "should not be expired after 0.6 second");
+      await new Promise((resolve) => setTimeout(resolve, 0.6 * 1000));
+      expect(await subject.get("A")).to.be.eq(undefined, "should be expired after 1.2 second");
+    });
+  });
+
+  describe.skip("#set", () => {});
+
+  describe("#del", () => {
+    it("should delete value", async () => {
+      await subject.set("A", 100);
+      expect(await subject.get("A")).to.be.eq(100);
+      expect(await subject.del("A")).to.be.eq(true);
+      expect(await subject.get("A")).to.be.eq(undefined);
+    });
+  });
+
+  describe("#getMulti", () => {
+    it("should return cached value", async () => {
+      await subject.set("A", 100);
+      await subject.set("B", 200);
+      await subject.set("C", 300);
+
+      expect(await subject.getMulti(["A", "B", "C", "D"])).to.be.deep.eq({
+        A: 100,
+        B: 200,
+        C: 300,
+        D: undefined,
+      });
+    });
+  });
+});

--- a/src/drivers/base.ts
+++ b/src/drivers/base.ts
@@ -7,13 +7,6 @@ export interface Driver {
   get<Result>(key: string): Promise<Result | undefined>;
 
   /**
-   * Get remaining TTL for the given key.
-   * @param key
-   * @Returns Promise<number>
-   */
-  ttl(key: string): Promise<number>;
-
-  /**
    * Retrieves a bunch of values from multiple keys.
    * @param keys all the keys that needs to be fetched
    * @return Promise<Result>
@@ -29,11 +22,12 @@ export interface Driver {
    * @return Promise<boolean>
    */
   set<Result>(key: string, value: Result, lifetime?: number): Promise<void>;
+  setMulti<Result>(items: { key: string; value: Result; lifetime?: number }[]): Promise<void>;
 
   del(key: string): Promise<boolean>;
 
   /**
-   * Flushes the memcached server.
+   * Flushes the cache server
    * @return Promise<void>
    */
   flush(): Promise<void>;

--- a/src/drivers/index.ts
+++ b/src/drivers/index.ts
@@ -1,2 +1,3 @@
 export * from "./redis";
 export * from "./redis_cluster";
+export * from "./local_storage";

--- a/src/drivers/local_storage.ts
+++ b/src/drivers/local_storage.ts
@@ -1,0 +1,45 @@
+import LRUCache = require("lru-cache");
+
+import { Driver } from "./base";
+
+export class LocalStorageDriver implements Driver {
+  private readonly store: LRUCache<string, any>;
+
+  constructor(options: LRUCache.Options<string, any> = {}) {
+    this.store = new LRUCache(options);
+  }
+
+  public async get<Result>(key: string): Promise<Result | undefined> {
+    return this.store.get(key) as Result | undefined;
+  }
+
+  public async set<Result>(key: string, value: Result, lifetime?: number): Promise<void> {
+    // LRU Cache ttl is in ms
+    this.store.set(key, value, lifetime ? lifetime * 1000 : undefined);
+  }
+
+  public async setMulti<Result>(items: { key: string; value: Result; lifetime?: number }[]): Promise<void> {
+    Promise.all(
+      items.map(
+        (item) => this.set<Result>(item.key, item.value, item.lifetime),
+      ),
+    );
+  }
+
+  public async del(key: string): Promise<boolean> {
+    this.store.del(key);
+    return true;
+  }
+
+  public async getMulti<Result>(keys: string[]): Promise<{ [key: string]: Result | undefined }> {
+    const result: { [key: string]: Result | undefined } = {};
+    for (const key of keys) {
+      result[key] = await this.get(key);
+    }
+    return result;
+  }
+
+  public async flush(): Promise<void> {
+    return this.store.reset();
+  }
+}

--- a/src/drivers/redis.ts
+++ b/src/drivers/redis.ts
@@ -53,10 +53,6 @@ export class RedisDriver implements Driver {
     }
   }
 
-  public async ttl(key: string): Promise<number> {
-    return await this.client.ttl(key);
-  }
-
   public async getMulti<Result>(keys: string[]) {
     if (keys.length === 0) {
       return {};
@@ -97,6 +93,14 @@ export class RedisDriver implements Driver {
     if (reply !== "OK") {
       throw new Error(`RedisDriver failed to set: '${key} - ${value}'`);
     }
+  }
+
+  public async setMulti<Result>(items: { key: string; value: Result; lifetime?: number }[]): Promise<void> {
+    Promise.all(
+      items.map(
+        (item) => this.set<Result>(item.key, item.value, item.lifetime),
+      ),
+    );
   }
 
   public async del(key: string) {

--- a/src/drivers/redis_cluster.ts
+++ b/src/drivers/redis_cluster.ts
@@ -62,10 +62,6 @@ export class RedisClusterDriver implements Driver {
     }
   }
 
-  public async ttl(key: string): Promise<number> {
-    return await this.client.ttl(key);
-  }
-
   // In cluster mode, MGET (multiple get) command requires all keys must be same key slot
   // if client does not handle this, redis will give "CROSSSLOT Keys in request don't hash to the same slot" Error.
   //
@@ -110,6 +106,14 @@ export class RedisClusterDriver implements Driver {
     if (reply !== "OK") {
       throw new Error(`RedisDriver failed to set: '${key} - ${value}'`);
     }
+  }
+
+  public async setMulti<Result>(items: { key: string; value: Result; lifetime?: number }[]): Promise<void> {
+    Promise.all(
+      items.map(
+        (item) => this.set<Result>(item.key, item.value, item.lifetime),
+      ),
+    );
   }
 
   public async del(key: string) {

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -88,15 +88,16 @@ export class CachedFetcher {
       Object.assign(mergedResult, localResult);
       // Propaginated upwards
       if (driverIndex > 0) {
+        const cashableItems: Array<{ key: string, value: Result, lifetime: number }> = [];
+        for (const key in localResult) {
+          const value = localResult[key];
+          if (value) {
+            cashableItems.push({ key, value, lifetime })
+          }
+        }
+
         await Promise.all(
-          this.drivers
-            .slice(0, driverIndex)
-            .map(async driver => {
-              for (const key in localResult) {
-                const value = localResult[key];
-                await driver.set(key, value, lifetime);
-              }
-            })
+          this.drivers.slice(0, driverIndex).map(driver => driver.setMulti(cashableItems))
         );
       }
       missingKeys = missingKeys.filter((key) => localResult[key] === undefined);
@@ -104,7 +105,6 @@ export class CachedFetcher {
       driverIndex ++;
       driver = this.drivers[driverIndex];
     }
-
     return mergedResult;
   }
 

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1,17 +1,13 @@
 import * as crypto from "crypto";
 import { Driver } from "./drivers/base";
 
-type Lifetime = {
-  cacheTime: number;
-  staleTime?: number;
-};
-
 type KeyTransform = (key: string) => string;
-export class MemcachedFetcher {
+
+export class CachedFetcher {
   public readonly keyTransform: KeyTransform;
 
   constructor(
-    private driver: Driver,
+    private drivers: Driver[],
     options: {
       keyTransform?:
         { type: "hashing", algorithm: "md5" } // Currently it only support md5
@@ -42,40 +38,97 @@ export class MemcachedFetcher {
     }
   }
 
-  public async fetch<Result>(key: string, lifetime: number | Lifetime, fetcher: () => Promise<Result>): Promise<Result> {
-    const hash = this.keyTransform(key);
+  /**
+   *
+   * @param transformedKey
+   * @returns
+   */
+  private async cascadedGet<Result>(
+    transformedKey: string,
+    lifetime: number
+  ) {
+    let value: Result | undefined = undefined;
+    for (let i = 0;i<this.drivers.length; i++) {
+      const driver = this.drivers[i];
 
-    const { cacheTime, staleTime = 0 } = typeof lifetime === "number"
-      ? { cacheTime: lifetime }
-      : lifetime;
+      value = await driver.get(transformedKey);
+      if (value !== undefined) {
+        // Fill missing top drivers
+        if (i > 0) {
+          await Promise.all(
+            this.drivers.slice(0, i).map(driver => driver.set(transformedKey, value, lifetime))
+          );
+        }
+        // And returns
+        return value;
+      }
+    }
+    return undefined;
+  }
 
-    const [cached, ttl] = await Promise.all([
-      this.driver.get<Result>(hash),
-      staleTime ? this.driver.ttl(hash) : Promise.resolve(0),
-    ]);
+  /**
+   * @param transformedKey
+   * @returns
+   */
+  private async cascadedMultiGet<Result>(
+    transformedKeys: string[],
+    lifetime: number
+  ) {
+    const mergedResult: { [key: string]: Result | undefined } = {};
 
-    if (!this.isValue(cached) || this.isStale(ttl, cacheTime, staleTime)) {
+    let missingKeys = transformedKeys;
+    let driverIndex = 0;
+    let driver = this.drivers[driverIndex];
+
+    // Every driver returns value, and if the next driver has value, it back fill drivers in front.
+    // this loops until driver ran out or keys are all have values
+    while (missingKeys.length > 0 && driver) {
+      const localResult = await driver.getMulti<Result>(missingKeys);
+      // Add to global result,
+      Object.assign(mergedResult, localResult);
+      // Propaginated upwards
+      if (driverIndex > 0) {
+        await Promise.all(
+          this.drivers
+            .slice(0, driverIndex)
+            .map(async driver => {
+              for (const key in localResult) {
+                const value = localResult[key];
+                await driver.set(key, value, lifetime);
+              }
+            })
+        );
+      }
+      missingKeys = missingKeys.filter((key) => localResult[key] === undefined);
+
+      driverIndex ++;
+      driver = this.drivers[driverIndex];
+    }
+
+    return mergedResult;
+  }
+
+  public async fetch<Result>(key: string, lifetime: number, fetcher: () => Promise<Result>): Promise<Result> {
+    const transformedKey = this.keyTransform(key);
+    const cached = await this.cascadedGet<Result>(key, lifetime);
+    if (!this.isValue<Result>(cached)) {
       try {
         const fetched = await fetcher();
-        await this.driver.set(hash, fetched, cacheTime);
+        await Promise.all(this.drivers.map(driver => driver.set(transformedKey, fetched, lifetime)));
         return fetched;
       } catch (e) {
         // If cached value is available, swallow thrown error and reuse cache
-        if (this.isValue(cached)) {
+        if (this.isValue<Result>(cached)) {
           return cached;
         }
-
-        // Otherwise throw error
         throw e;
       }
     }
-
     return cached;
   }
 
   public async del(key: string) {
-    const hash = this.keyTransform(key);
-    return await this.driver.del(hash);
+    await Promise.all(this.drivers.map(driver => driver.del(this.keyTransform(key))));
   }
 
   public async multiFetch<Argument, Result>(
@@ -96,15 +149,15 @@ export class MemcachedFetcher {
       }
     })();
 
-    const argsToKeyMap = new Map<Argument, string>(
+    const argsToTransformedKeyMap = new Map<Argument, string>(
       args.map((arg) => {
-        const hash = this.keyTransform(`${namespace}:${argToKey(arg).toString()}`);
-        return [arg, hash] as const;
+        const transformedKey = this.keyTransform(`${namespace}:${argToKey(arg).toString()}`);
+        return [arg, transformedKey] as const;
       })
     );
 
-    const cached = await this.driver.getMulti<Result>(Array.from(argsToKeyMap.values()));
-    const missingArgs = args.filter((arg) => !this.isValue(cached[argsToKeyMap.get(arg)!]));
+    const cached = await this.cascadedMultiGet<Result>(Array.from(argsToTransformedKeyMap.values()), lifetime);
+    const missingArgs = args.filter((arg) => !this.isValue(cached[argsToTransformedKeyMap.get(arg)!]));
 
     const fetchedArray = missingArgs.length > 0 ? await fetcher(missingArgs) : [];
 
@@ -114,19 +167,17 @@ export class MemcachedFetcher {
     const fetched = new Map<Argument, Result>(
       missingArgs.map((arg, index) => [arg, fetchedArray[index]] as [Argument, Result]));
 
-    await Promise.all(
-      Array.from(fetched).map(async ([arg, result]) => {
-        if (this.isValue(result)) {
-          await this.driver.set(argsToKeyMap.get(arg)!, result, lifetime);
-        } else {
-          // if fetcher returns undefined, that means user intentionally not want to cache this value
-        }
-      }),
-    );
+    const cachableItems: Array<{ key: string, value: Result, lifetime: number }> = [];
+    Array.from(fetched).forEach(async ([arg, result]) => {
+      if (this.isValue(result)) {
+        cachableItems.push({ key: argsToTransformedKeyMap.get(arg)!, value: result, lifetime });
+      }
+    })
+    await Promise.all(this.drivers.map(driver => driver.setMulti(cachableItems)));
 
     return args.map((arg) => {
-      const hash = argsToKeyMap.get(arg)!;
-      const value = cached[hash];
+      const transformedKey = argsToTransformedKeyMap.get(arg)!;
+      const value = cached[transformedKey];
       if (this.isValue(value)) {
         return value;
       } else {
@@ -149,14 +200,10 @@ export class MemcachedFetcher {
 
     await Promise.all(
       args.map(async (arg) => {
-        const hashedKey = this.keyTransform(`${namespace}:${argToKey(arg).toString()}`);
-        await this.driver.del(hashedKey);
+        const key = this.keyTransform(`${namespace}:${argToKey(arg).toString()}`);
+        await Promise.all(this.drivers.map(driver => driver.del(key)));
       })
     );
-  }
-
-  private isStale(ttl: number, cacheTime: number, staleTime?: number): boolean {
-    return !!staleTime && ttl > 0 && (cacheTime - staleTime) > ttl;
   }
 
   private isValue<T>(value: T | undefined | null): value is T {


### PR DESCRIPTION
- Renaming MemcachedFetcher to CachedFetcher, since it's just legacy of era when we only had memcached driver.
- add LocalStorageDriver using lru-cache
- add CachedFetcher ability to have multi layered drivers.


Multilayer cache extensively tested on https://github.com/serverless-seoul/cache/compare/feature/multi-layer-cache?expand=1#diff-554e83eea6c35fa3ef4c91968c7f9fefeae4f475b9bb80dc04e39aff1c218a91R13 

in summary for #fetch,
- When looking up keys, it starts looking from drivers[start] => drivers[end]
- on each step, only the missing keys will be carried to next driver. if L1 has key, we don't look up that on L2
- when we find missing keys in L2, it propagated to L1. (#cascadedGet / #cascadedMultiGet)

some caveats:
## 1. When propagate cache from lower lever to higher level, we don't copy TTL - we assume max TTL
**This can cause value having (max TTL * 2) in worst case**
for example)
```
fetch(["A, B"], TTL = 100)
L1 (value=A, TTL=1)
L2 (value=B, TTL=50)
```
on here optimal behavior will be to do
```
L1 (value=A, TTL=1), (value=B, TTL=50)
L2 (value=B, TTL=50)
```

instead, we do 
```
L1 (value=A, TTL=1), (value=B, TTL=100)
L2 (value=B, TTL=50)
```
this is due to avoid extra TTL query to L2 cache, since most of cache drivers (including Redis) doesn't have way to get TTL and Value at the same time.

## 2. When keys are missing on all the levels of caches, currently behavior is to lookup everything
so if you have some logic that do #get() on empty key intentionally, this cause (number of drivers) X (call count) traffic. 