### PR TITLE
Feature/strict ttl propagation

### DIFF
--- a/src/__test__/fetcher_spec.ts
+++ b/src/__test__/fetcher_spec.ts
@@ -79,16 +79,16 @@ describe(CachedFetcher.name, () => {
         });
       });
 
-      context.only("with strictTTL=on", () => {
+      context("with strictTTL=on", () => {
         it("should propaginate TTL value", async () => {
           const fetcher = async () => 100;
           const key = "random-key";
-          const maxTTL = 10;
+          const maxTTL = 2;
           const L2TTL = 1;
 
           // Fill L2
-          await drivers[1].set(`a:${key}`, await fetcher(), 1);
-          expect(await subject.fetch(key, maxTTL, fetcher))
+          await drivers[1].set(`a:${key}`, await fetcher(), L2TTL);
+          expect(await subject.fetch(key, { lifetime: maxTTL, strict: true }, fetcher))
             .to.be.deep.eq(100);
 
           expect(await drivers[0].get(`a:${key}`)).to.be.eq(100, "L1 should have value initially");
@@ -96,17 +96,38 @@ describe(CachedFetcher.name, () => {
           expect(await drivers[0].get(`a:${key}`)).to.be.eq(undefined, "L1 should expire the value after L2 TTL");
         });
       });
+
+      context("with strictTTL=off", () => {
+        it("should not propaginate TTL value", async () => {
+          const fetcher = async () => 100;
+          const key = "random-key";
+          const maxTTL = 2;
+          const L2TTL = 1;
+
+          // Fill L2
+          await drivers[1].set(`a:${key}`, await fetcher(), L2TTL);
+          expect(await subject.fetch(key, { lifetime: maxTTL, strict: false }, fetcher))
+            .to.be.deep.eq(100);
+
+          expect(await drivers[0].get(`a:${key}`)).to.be.eq(100, "L1 should have value initially");
+          await sleep(L2TTL);
+          expect(await drivers[0].get(`a:${key}`)).to.be.eq(100, "L1 should not expire the value after L2 TTL");
+          await sleep(maxTTL);
+          expect(await drivers[0].get(`a:${key}`)).to.be.eq(undefined, "L1 should expire the value after max TTL");
+        });
+      });
     });
 
     describe("#multiFetch", () => {
       const L1 = new LocalStorageDriver();
-      const L2 = new LocalStorageDriver();
+      const L2 = new RedisDriver(process.env.REDIS_URL as string);
       const L3 = new LocalStorageDriver();
       const drivers = [L1, L2, L3] as const;
-      const subject: CachedFetcher = new CachedFetcher([...drivers]);
+      let subject: CachedFetcher;
 
       beforeEach(async () => {
         await Promise.all(drivers.map((driver) => driver.flush()));
+        subject = new CachedFetcher([...drivers]);
       });
 
       context("when cache has cascaded discrepency", () => {
@@ -154,6 +175,54 @@ describe(CachedFetcher.name, () => {
             "key:B": "B-L3",
             "key:C": "C",
             "key:D": "NEW",
+          });
+        });
+
+        context("with TTL propagination", () => {
+          beforeEach(() => {
+            subject = new CachedFetcher([L1, L2]);
+          });
+
+          context("with strictTTL=on", () => {
+            it("should propaginate TTL value", async () => {
+              const maxTTL = 2;
+              const L2TTL = 1;
+
+              // Fill L2
+              await L2.set("v1:1", "old-1", L2TTL);
+              await subject.multiFetch(
+                [1, 2],
+                "v1",
+                { lifetime: maxTTL, strict: true },
+                async (args) => args.map((arg) => `new-${arg}`),
+              );
+
+              expect(await L1.get("v1:1")).to.be.eq("old-1", "L1 should have value initially");
+              await sleep(L2TTL);
+              expect(await L1.get("v1:1")).to.be.eq(undefined, "L1 should expire the value after L2 TTL");
+            });
+          });
+
+          context("with strictTTL=off", () => {
+            it("should propaginate TTL value", async () => {
+              const maxTTL = 2;
+              const L2TTL = 1;
+
+              // Fill L2
+              await L2.set("v1:1", "old-1", L2TTL);
+              await subject.multiFetch(
+                [1, 2],
+                "v1",
+                { lifetime: maxTTL, strict: false },
+                async (args) => args.map((arg) => `new-${arg}`),
+              );
+
+              expect(await L1.get("v1:1")).to.be.eq("old-1", "L1 should have value initially");
+              await sleep(L2TTL);
+              expect(await L1.get("v1:1")).to.be.eq("old-1", "L1 should not expire value after L2 TTL");
+              await sleep(maxTTL);
+              expect(await L1.get("v1:1")).to.be.eq(undefined, "L1 should expire maxTTL");
+            });
           });
         });
       });

--- a/src/drivers/base.ts
+++ b/src/drivers/base.ts
@@ -27,6 +27,14 @@ export interface Driver {
   del(key: string): Promise<boolean>;
 
   /**
+   * remaing lifetime of given key (in second)
+   * positive number means => lifetime
+   * undefined means => key exists but doesn't have expiration
+   * null means => key doesn't exists
+   */
+   ttl(key: string): Promise<number | undefined | null>;
+
+  /**
    * Flushes the cache server
    * @return Promise<void>
    */

--- a/src/drivers/local_storage.ts
+++ b/src/drivers/local_storage.ts
@@ -21,7 +21,7 @@ export class LocalStorageDriver implements Driver {
   public async setMulti<Result>(items: { key: string; value: Result; lifetime?: number }[]): Promise<void> {
     // since this.set is not really async anyway...
     for (const item of items) {
-      await this.set<Result>(item.key, item.value, item.lifetime)
+      await this.set<Result>(item.key, item.value, item.lifetime);
     }
   }
 

--- a/src/drivers/local_storage.ts
+++ b/src/drivers/local_storage.ts
@@ -19,11 +19,10 @@ export class LocalStorageDriver implements Driver {
   }
 
   public async setMulti<Result>(items: { key: string; value: Result; lifetime?: number }[]): Promise<void> {
-    Promise.all(
-      items.map(
-        (item) => this.set<Result>(item.key, item.value, item.lifetime),
-      ),
-    );
+    // since this.set is not really async anyway...
+    for (const item of items) {
+      await this.set<Result>(item.key, item.value, item.lifetime)
+    }
   }
 
   public async ttl(key: string): Promise<number> {

--- a/src/drivers/local_storage.ts
+++ b/src/drivers/local_storage.ts
@@ -26,6 +26,10 @@ export class LocalStorageDriver implements Driver {
     );
   }
 
+  public async ttl(key: string): Promise<number> {
+    throw new Error("LocalStorageDriver doesn't support #ttl");
+  }
+
   public async del(key: string): Promise<boolean> {
     this.store.del(key);
     return true;

--- a/src/drivers/redis.ts
+++ b/src/drivers/redis.ts
@@ -96,7 +96,7 @@ export class RedisDriver implements Driver {
   }
 
   public async setMulti<Result>(items: { key: string; value: Result; lifetime?: number }[]): Promise<void> {
-    Promise.all(
+    await Promise.all(
       items.map(
         (item) => this.set<Result>(item.key, item.value, item.lifetime),
       ),

--- a/src/drivers/redis.ts
+++ b/src/drivers/redis.ts
@@ -103,6 +103,20 @@ export class RedisDriver implements Driver {
     );
   }
 
+  public async ttl(key: string): Promise<number | undefined | null> {
+    const ttl = await this.client.ttl(key);
+    // https://redis.io/commands/TTL
+    if (ttl === -2) {
+      // The command returns -2 if the key does not exist.
+      return null;
+    } else if (ttl === -1) {
+      // The command returns -1 if the key exists but has no associated expire.
+      return undefined;
+    } else {
+      return ttl;
+    }
+  }
+
   public async del(key: string) {
     // @see https://redis.io/commands/del#return-value
     // @type Integer reply: The number of keys that were removed.

--- a/src/drivers/redis_cluster.ts
+++ b/src/drivers/redis_cluster.ts
@@ -91,6 +91,20 @@ export class RedisClusterDriver implements Driver {
     }, {} as { [key: string]: Result | undefined });
   }
 
+  public async ttl(key: string): Promise<number> {
+    const ttl = await this.client.ttl(key);
+    // https://redis.io/commands/TTL
+    if (ttl === -2) {
+      // The command returns -2 if the key does not exist.
+      return 0;
+    } else if (ttl === -1) {
+      // The command returns -1 if the key exists but has no associated expire.
+      return -1;
+    } else {
+      return ttl;
+    }
+  }
+
   public async set<Result>(key: string, value: Result, lifetime?: number) {
     const serialized = JSON.stringify(value);
 


### PR DESCRIPTION
## Strict TTL (Propaginating TTL) feature

when you're using multi layer cache, current behavior of feeling top cache with bottom cache is to use maximum TTL.

```
fetch(["A, B"], TTL = 100)
L1 (value=A, TTL=1)
L2 (value=B, TTL=50)
```
this causes
```
L1 (value=A, TTL=1), (value=B, TTL=100)
L2 (value=B, TTL=50)
```

optimal (most reliable TTL) behavior should be 
````
L1 (value=A, TTL=1), (value=B, TTL=50)
L2 (value=B, TTL=50)
```
but this causes extra getTTL() query to L2 cache. 

thus, we add strict: boolean option. 

## 1. strict = false (default) 
Pros: doesn't create extra TTL query. just get() or getMulti()
Cons: can cause actual lifetime being maximum TTL * 2 in worse case.
*use it when exact TTL is not really important*

## 2. strict = true
Pros:  TTL is synced through out different layers of caches.
Cons: cause extra TTL query
*use it when TTL has to be all synced*

